### PR TITLE
change default scope, restrict search to inbox, change server to api.protonmail.ch

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -56,7 +56,7 @@ function checkit()
 		}
 	});
 	
-	var senddata = { Username: container.email, Password: container.password, ResponseType: "token", ClientID: clientID, ClientSecret: clientSecret, GrantType: "password", RedirectURI: "https://protonmail.ch", State: randomString(15), Scope: "" };
+	var senddata = { Username: container.email, Password: container.password, ResponseType: "token", ClientID: clientID, ClientSecret: clientSecret, GrantType: "password", RedirectURI: "https://protonmail.ch", State: randomString(15), Scope: "full mail" };
 	$.ajax({
 		url: 'https://api.protonmail.ch/auth',
 		method: 'POST',

--- a/js/background.js
+++ b/js/background.js
@@ -58,7 +58,7 @@ function checkit()
 	
 	var senddata = { Username: container.email, Password: container.password, ResponseType: "token", ClientID: clientID, ClientSecret: clientSecret, GrantType: "password", RedirectURI: "https://protonmail.ch", State: randomString(15), Scope: "" };
 	$.ajax({
-		url: 'https://mail.protonmail.com/api/auth',
+		url: 'https://api.protonmail.ch/auth',
 		method: 'POST',
 		data: JSON.stringify(senddata),
 		success: function(data3) {
@@ -85,7 +85,7 @@ function checkit()
 					});
 					
 					$.ajax({
-						url: 'https://mail.protonmail.com/api/messages?Location=0&Unread=1',
+						url: 'https://api.protonmail.ch/messages?Location=0&Unread=1',
 						method: 'GET',
 						success: function(data4) {
 							parseContent(data4);
@@ -198,7 +198,7 @@ function popup_press(notificationId, buttonIndex)
 	{
 		var senddata = {"IDs":[notificationId]};
 		$.ajax({
-			url: 'https://mail.protonmail.com/api/messages/read',
+			url: 'https://api.protonmail.ch/messages/read',
 			method: 'PUT',
 			data: JSON.stringify(senddata),
 			success: function(data5) {
@@ -217,7 +217,7 @@ function popup_press(notificationId, buttonIndex)
 function get_message(id, func)
 {
 	$.ajax({
-		url: 'https://mail.protonmail.com/api/messages/'+id,
+		url: 'https://api.protonmail.ch/messages/'+id,
 		method: 'GET',
 		success: function(data5) {
 			pgpMessage = openpgp.message.readArmored(data5.Message.Body);

--- a/js/background.js
+++ b/js/background.js
@@ -56,9 +56,9 @@ function checkit()
 		}
 	});
 	
-	var senddata = { Username: container.email, Password: container.password, ResponseType: "token", ClientID: clientID, ClientSecret: clientSecret, GrantType: "password", RedirectURI: "https://protonmail.ch", State: randomString(15), Scope: "full" };
+	var senddata = { Username: container.email, Password: container.password, ResponseType: "token", ClientID: clientID, ClientSecret: clientSecret, GrantType: "password", RedirectURI: "https://protonmail.ch", State: randomString(15), Scope: "" };
 	$.ajax({
-		url: 'https://protonmail.com/api/auth',
+		url: 'https://mail.protonmail.com/api/auth',
 		method: 'POST',
 		data: JSON.stringify(senddata),
 		success: function(data3) {
@@ -85,7 +85,7 @@ function checkit()
 					});
 					
 					$.ajax({
-						url: 'https://protonmail.com/api/messages?Unread=1',
+						url: 'https://mail.protonmail.com/api/messages?Location=0&Unread=1',
 						method: 'GET',
 						success: function(data4) {
 							parseContent(data4);
@@ -198,7 +198,7 @@ function popup_press(notificationId, buttonIndex)
 	{
 		var senddata = {"IDs":[notificationId]};
 		$.ajax({
-			url: 'https://protonmail.com/api/messages/read',
+			url: 'https://mail.protonmail.com/api/messages/read',
 			method: 'PUT',
 			data: JSON.stringify(senddata),
 			success: function(data5) {
@@ -217,7 +217,7 @@ function popup_press(notificationId, buttonIndex)
 function get_message(id, func)
 {
 	$.ajax({
-		url: 'https://protonmail.com/api/messages/'+id,
+		url: 'https://mail.protonmail.com/api/messages/'+id,
 		method: 'GET',
 		success: function(data5) {
 			pgpMessage = openpgp.message.readArmored(data5.Message.Body);


### PR DESCRIPTION
Not tested. Very soon 'mail' scope will be required to access mail, so setting the Scope parameter to "full mail" to ensure your users will still be able to use your extension. I also changed the API server to the long-term one--the protonmail.com/api one will probably be removed at some point.

P.S. I didn't see any logout code. Do you log the user out between checks or create a new session every time you check for mail? Can you fix this? Lots of dead tokens are really a problem but they aren't great either.